### PR TITLE
🧭 Mejorando navegación | Navegar con rutas con nombre

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 
+import 'package:components_app_v3/src/pages/alerts_page.dart';
+import 'package:components_app_v3/src/pages/avatars_page.dart';
 import 'package:flutter/material.dart';
 
 import 'src/pages/home_page.dart';
@@ -13,7 +15,16 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'App Componentes',
       debugShowCheckedModeBanner: false,
-      home:HomePage()  
+
+      initialRoute: '/',
+      routes: <String, WidgetBuilder> {
+
+        
+        '/'       : (BuildContext context ) => HomePage(),
+        'alert'   : (BuildContext context ) => AlertsPage(),
+        'avatar'  : (BuildContext context ) => AvatarsPage(),
+
+      },  
       // HomePageTemp(),
     );
   }

--- a/lib/src/pages/home_page.dart
+++ b/lib/src/pages/home_page.dart
@@ -62,26 +62,29 @@ return FutureBuilder(
         trailing: Icon(LineIcons.chevronRight, color: Colors.blueAccent),
         onTap:  (){ 
             
-            final route = MaterialPageRoute(
-              builder: (context)=> AlertsPage()
+          
 
-            );
+          Navigator.pushNamed( context, opt['ruta'] );
 
-            Navigator.push(context, route);
+
+
+
+          // Forma estática de navegar entre páginas 
+
+            // final route = MaterialPageRoute(
+            //   builder: (context)=> AlertsPage()
+
+            // );
+
+            // Navigator.push(context, route);
 
 
         },
-
-
-
 
       );
 
       opciones..add(widgetTemp)
               ..add( Divider());
-
-
-
 
      });
 


### PR DESCRIPTION
_Se cambio la forma de ir a una página ya que tenias un sete de rutas fijas a 1 sóla página por defecto, comenzamos a utilizar otra función o propiedad de navigator a la cual le estamos pasando como parámetro el string de la ruta para cada página que viene de nuestro JSON en el campo ruta_
_Ej:_ 
```
`
          Navigator.pushNamed( context, opt['ruta'] );`
```

_Definimos nuestras rutas con las cuales trabajar directamente en nuestro archivo main.dart de forma tal que estámos indicando hacía qué página queremos nevegar ante cada String que se pase como parámetro, de paso estamos colocando estas definiciones donde llamabamos antes a nuestra homepage()._



_Ej:_

      initialRoute: '/',
      routes: <String, WidgetBuilder> {

        
        '/'       : (BuildContext context ) => HomePage(),
        'alert'   : (BuildContext context ) => AlertsPage(),
        'avatar'  : (BuildContext context ) => AvatarsPage(),

      },  



